### PR TITLE
Fix save corruption when player has non-empty factories in inventory

### DIFF
--- a/Free_Real_Estate_1.0.3/factory/factory.lua
+++ b/Free_Real_Estate_1.0.3/factory/factory.lua
@@ -527,7 +527,7 @@ function Factory:freeze()
 				-- disable all entities for performance
 				-- as long as we're here anyway make sure players can't get any of these buildings back somehow if this is actually a
 				-- leaked destroyed factory and they've found a way to get inside it
-				self.restore[entity] = {entity.operable, entity.active, entity.minable, entity.destructible}
+				table.insert(self.restore,{ent=entity, flags={entity.operable, entity.active, entity.minable, entity.destructible}})
 				entity.operable = false
 				entity.active = false
 				entity.minable = false
@@ -568,13 +568,13 @@ end
 function Factory:restore_entities()
 	local surface = game.surfaces['free_real_estate']
 
-	for entity, flags in pairs(self.restore) do
+	for _, entData in pairs(self.restore) do
 		-- entity can be invalid here if we caught something temporary like smoke
-		if(entity.valid) then
-			entity.operable = flags[1]
-			entity.active = flags[2]
-			entity.minable = flags[3]
-			entity.destructible = flags[4]
+		if(entData.ent.valid) then
+			entData.ent.operable = entData.flags[1]
+			entData.ent.active = entData.flags[2]
+			entData.ent.minable = entData.flags[3]
+			entData.ent.destructible = entData.flags[4]
 		end
 	end
 


### PR DESCRIPTION
This change fixes save corruption that causes a "too many local variables in main function" error when loading saves in which the player has non-empty factories in their inventory.

I have not done a full review of the code for where else it might use objects as the key for global variables but this fix removes all the `local table###={...};_.factories[<factoryName>].restore(table###)` bloat that appeared in my corrupted save. 

Just some more info I wrote up before I realized the fix was not going to be time consuming.

The only factories plagued by the locals were factories that were in my inventory. Factories that were placed in the world(I had around 10-15) were just fine.
I can consistently cause this bug by loading a working save, picking up some factories and creating a new save which then fails to load.